### PR TITLE
Patch provider error handling

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -282,6 +282,7 @@ impl<M: Middleware> CCIPReadMiddleware<M> {
 
         let decoded_data: Vec<Token> = abi::decode(&output_types, &result[4..])?;
 
+        #[allow(clippy::get_first)]
         let (
             Some(Token::Address(sender)),
             Some(Token::Array(urls)),


### PR DESCRIPTION
There's a logic issue with isolating OffchainLookup errors resulting in other errors from the inner provider not being returned correctly. This PR should fix that.